### PR TITLE
fix(LMP-6728): patch `bundle` file to remove memory leak

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { Predicate } from 'effect';
 import type { BuildOptions } from 'esbuild';
-import * as pkg from 'esbuild';
+import { build } from 'esbuild';
 import fs from 'fs-extra';
 import pMap from 'p-map';
 import path from 'path';
@@ -9,7 +9,7 @@ import { uniq } from 'ramda';
 
 import type EsbuildServerlessPlugin from './index';
 import { asArray, assertIsString, isESM } from './helper';
-import type { EsbuildOptions, FileBuildResult, FunctionBuildResult, BuildContext } from './types';
+import type { EsbuildOptions, FileBuildResult, FunctionBuildResult } from './types';
 import { trimExtension } from './utils';
 
 const getStringArray = (input: unknown): string[] => asArray(input).filter(Predicate.isString);
@@ -105,19 +105,7 @@ export async function bundle(this: EsbuildServerlessPlugin): Promise<void> {
       outdir: path.join(buildDirPath, path.dirname(entry)),
     };
 
-    type ContextFn = (opts: typeof options) => Promise<BuildContext>;
-    type WithContext = typeof pkg & { context?: ContextFn };
-    const context = buildOptions.skipRebuild ? undefined : await (pkg as WithContext).context?.(options);
-
-    let result;
-    if (!buildOptions.skipRebuild) {
-      result = await context?.rebuild();
-      if (!result) {
-        result = await pkg.build(options);
-      }
-    } else {
-      result = await pkg.build(options);
-    }
+    const result = await build(options);
 
     if (config.metafile) {
       fs.writeFileSync(
@@ -126,7 +114,7 @@ export async function bundle(this: EsbuildServerlessPlugin): Promise<void> {
       );
     }
 
-    return { bundlePath, entry, result, context };
+    return { bundlePath, entry, result };
   };
 
   // Files can contain multiple handlers for multiple functions, we want to get only the unique ones


### PR DESCRIPTION
This fix was suggested in the following thread on the upstream repo:

https://github.com/floydspace/serverless-esbuild/issues/388